### PR TITLE
get back vanished pagetools

### DIFF
--- a/css/template.css
+++ b/css/template.css
@@ -132,6 +132,11 @@ main {
   font-size: .9em;
 }
 
+#dokuwiki__top {
+	margin-right: 16px;
+	margin-left: 16px;
+}
+	
 /*#dokuwiki__content .page-header {
   margin-top: 10px;
 }*/
@@ -173,7 +178,7 @@ main {
 #dw__pagetools {
   position: absolute;
   top: 2em;
-  right: -40px;
+  right: -32px;
   width: 40px;
 }
 


### PR DESCRIPTION
The page tools are almost not visible on firefox and chromium in ubuntu 15.04. increasing the margins on the right (and left for symmetry) and reducing the offset of the pagetools fixes that.
