### PR TITLE
Bootswatch fonts / CSS file fixes

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -131,6 +131,7 @@ class Template
         $bootstrap_theme  = $this->getConf('bootstrapTheme');
         $fixed_top_navbar = $this->getConf('fixedTopNavbar');
         $tpl_basedir      = tpl_basedir();
+        $tpl_incdir       = tpl_incdir();
 
         $stylesheets = array();
         $scripts     = array();
@@ -151,7 +152,7 @@ class Template
                 $bootswatch_theme = $this->getBootswatchTheme();
                 $bootswatch_url   = $tpl_basedir . 'assets/bootstrap';
 
-                if (file_exists($tpl_basedir . "assets/fonts/$bootswatch_theme.fonts.css")) {
+                if (file_exists($tpl_incdir . "assets/fonts/$bootswatch_theme.fonts.css")) {
                     $stylesheets[] = $tpl_basedir . "assets/fonts/$bootswatch_theme.fonts.css";
                 }
 

--- a/assets/fonts/cosmo.fonts.css
+++ b/assets/fonts/cosmo.fonts.css
@@ -8,7 +8,8 @@
 		url('Source_Sans_Pro_300.eot?#iefix') format('embedded-opentype'),
 		url('Source_Sans_Pro_300.woff') format('woff'),
 		url('Source_Sans_Pro_300.woff2') format('woff2'),
-		url('Source_Sans_Pro_300.svg#SourceSansPro') format('svg'),
+		url('Source_Sans_Pro_300.svg#SourceSansPro') format('svg');
+}
 @font-face {
 	font-family: 'Source Sans Pro';
 	font-style: normal;
@@ -19,7 +20,8 @@
 		url('Source_Sans_Pro_400.eot?#iefix') format('embedded-opentype'),
 		url('Source_Sans_Pro_400.woff') format('woff'),
 		url('Source_Sans_Pro_400.woff2') format('woff2'),
-		url('Source_Sans_Pro_400.svg#SourceSansPro') format('svg'),
+		url('Source_Sans_Pro_400.svg#SourceSansPro') format('svg');
+}
 @font-face {
 	font-family: 'Source Sans Pro';
 	font-style: normal;
@@ -30,4 +32,5 @@
 		url('Source_Sans_Pro_700.eot?#iefix') format('embedded-opentype'),
 		url('Source_Sans_Pro_700.woff') format('woff'),
 		url('Source_Sans_Pro_700.woff2') format('woff2'),
-		url('Source_Sans_Pro_700.svg#SourceSansPro') format('svg'),
+		url('Source_Sans_Pro_700.svg#SourceSansPro') format('svg');
+}

--- a/assets/fonts/cyborg.fonts.css
+++ b/assets/fonts/cyborg.fonts.css
@@ -8,7 +8,8 @@
 		url('Roboto_400.eot?#iefix') format('embedded-opentype'),
 		url('Roboto_400.woff') format('woff'),
 		url('Roboto_400.woff2') format('woff2'),
-		url('Roboto_400.svg#Roboto') format('svg'),
+		url('Roboto_400.svg#Roboto') format('svg');
+}
 @font-face {
 	font-family: 'Roboto';
 	font-style: normal;
@@ -19,4 +20,5 @@
 		url('Roboto_700.eot?#iefix') format('embedded-opentype'),
 		url('Roboto_700.woff') format('woff'),
 		url('Roboto_700.woff2') format('woff2'),
-		url('Roboto_700.svg#Roboto') format('svg'),
+		url('Roboto_700.svg#Roboto') format('svg');
+}

--- a/assets/fonts/darkly.fonts.css
+++ b/assets/fonts/darkly.fonts.css
@@ -8,7 +8,8 @@
 		url('Lato_400.eot?#iefix') format('embedded-opentype'),
 		url('Lato_400.woff') format('woff'),
 		url('Lato_400.woff2') format('woff2'),
-		url('Lato_400.svg#Lato') format('svg'),
+		url('Lato_400.svg#Lato') format('svg');
+}
 @font-face {
 	font-family: 'Lato';
 	font-style: normal;
@@ -19,7 +20,8 @@
 		url('Lato_700.eot?#iefix') format('embedded-opentype'),
 		url('Lato_700.woff') format('woff'),
 		url('Lato_700.woff2') format('woff2'),
-		url('Lato_700.svg#Lato') format('svg'),
+		url('Lato_700.svg#Lato') format('svg');
+}
 @font-face {
 	font-family: 'Lato';
 	font-style: italic;
@@ -30,4 +32,5 @@
 		url('Lato_400italic.eot?#iefix') format('embedded-opentype'),
 		url('Lato_400italic.woff') format('woff'),
 		url('Lato_400italic.woff2') format('woff2'),
-		url('Lato_400italic.svg#Lato') format('svg'),
+		url('Lato_400italic.svg#Lato') format('svg');
+}

--- a/assets/fonts/flatly.fonts.css
+++ b/assets/fonts/flatly.fonts.css
@@ -8,7 +8,8 @@
 		url('Lato_400.eot?#iefix') format('embedded-opentype'),
 		url('Lato_400.woff') format('woff'),
 		url('Lato_400.woff2') format('woff2'),
-		url('Lato_400.svg#Lato') format('svg'),
+		url('Lato_400.svg#Lato') format('svg');
+}
 @font-face {
 	font-family: 'Lato';
 	font-style: normal;
@@ -19,7 +20,8 @@
 		url('Lato_700.eot?#iefix') format('embedded-opentype'),
 		url('Lato_700.woff') format('woff'),
 		url('Lato_700.woff2') format('woff2'),
-		url('Lato_700.svg#Lato') format('svg'),
+		url('Lato_700.svg#Lato') format('svg');
+}
 @font-face {
 	font-family: 'Lato';
 	font-style: italic;
@@ -30,4 +32,5 @@
 		url('Lato_400italic.eot?#iefix') format('embedded-opentype'),
 		url('Lato_400italic.woff') format('woff'),
 		url('Lato_400italic.woff2') format('woff2'),
-		url('Lato_400italic.svg#Lato') format('svg'),
+		url('Lato_400italic.svg#Lato') format('svg');
+}

--- a/assets/fonts/journal.fonts.css
+++ b/assets/fonts/journal.fonts.css
@@ -8,7 +8,8 @@
 		url('News_Cycle_400.eot?#iefix') format('embedded-opentype'),
 		url('News_Cycle_400.woff') format('woff'),
 		url('News_Cycle_400.woff2') format('woff2'),
-		url('News_Cycle_400.svg#NewsCycle') format('svg'),
+		url('News_Cycle_400.svg#NewsCycle') format('svg');
+}
 @font-face {
 	font-family: 'News Cycle';
 	font-style: normal;
@@ -19,4 +20,5 @@
 		url('News_Cycle_700.eot?#iefix') format('embedded-opentype'),
 		url('News_Cycle_700.woff') format('woff'),
 		url('News_Cycle_700.woff2') format('woff2'),
-		url('News_Cycle_700.svg#NewsCycle') format('svg'),
+		url('News_Cycle_700.svg#NewsCycle') format('svg');
+}

--- a/assets/fonts/lumen.fonts.css
+++ b/assets/fonts/lumen.fonts.css
@@ -8,7 +8,8 @@
 		url('Source_Sans_Pro_300.eot?#iefix') format('embedded-opentype'),
 		url('Source_Sans_Pro_300.woff') format('woff'),
 		url('Source_Sans_Pro_300.woff2') format('woff2'),
-		url('Source_Sans_Pro_300.svg#SourceSansPro') format('svg'),
+		url('Source_Sans_Pro_300.svg#SourceSansPro') format('svg');
+}
 @font-face {
 	font-family: 'Source Sans Pro';
 	font-style: normal;
@@ -19,7 +20,8 @@
 		url('Source_Sans_Pro_400.eot?#iefix') format('embedded-opentype'),
 		url('Source_Sans_Pro_400.woff') format('woff'),
 		url('Source_Sans_Pro_400.woff2') format('woff2'),
-		url('Source_Sans_Pro_400.svg#SourceSansPro') format('svg'),
+		url('Source_Sans_Pro_400.svg#SourceSansPro') format('svg');
+}
 @font-face {
 	font-family: 'Source Sans Pro';
 	font-style: normal;
@@ -30,7 +32,8 @@
 		url('Source_Sans_Pro_700.eot?#iefix') format('embedded-opentype'),
 		url('Source_Sans_Pro_700.woff') format('woff'),
 		url('Source_Sans_Pro_700.woff2') format('woff2'),
-		url('Source_Sans_Pro_700.svg#SourceSansPro') format('svg'),
+		url('Source_Sans_Pro_700.svg#SourceSansPro') format('svg');
+}
 @font-face {
 	font-family: 'Source Sans Pro';
 	font-style: italic;
@@ -41,4 +44,5 @@
 		url('Source_Sans_Pro_400italic.eot?#iefix') format('embedded-opentype'),
 		url('Source_Sans_Pro_400italic.woff') format('woff'),
 		url('Source_Sans_Pro_400italic.woff2') format('woff2'),
-		url('Source_Sans_Pro_400italic.svg#SourceSansPro') format('svg'),
+		url('Source_Sans_Pro_400italic.svg#SourceSansPro') format('svg');
+}

--- a/assets/fonts/paper.fonts.css
+++ b/assets/fonts/paper.fonts.css
@@ -8,7 +8,8 @@
 		url('Roboto_300.eot?#iefix') format('embedded-opentype'),
 		url('Roboto_300.woff') format('woff'),
 		url('Roboto_300.woff2') format('woff2'),
-		url('Roboto_300.svg#Roboto') format('svg'),
+		url('Roboto_300.svg#Roboto') format('svg');
+}
 @font-face {
 	font-family: 'Roboto';
 	font-style: normal;
@@ -19,7 +20,8 @@
 		url('Roboto_400.eot?#iefix') format('embedded-opentype'),
 		url('Roboto_400.woff') format('woff'),
 		url('Roboto_400.woff2') format('woff2'),
-		url('Roboto_400.svg#Roboto') format('svg'),
+		url('Roboto_400.svg#Roboto') format('svg');
+}
 @font-face {
 	font-family: 'Roboto';
 	font-style: normal;
@@ -30,7 +32,8 @@
 		url('Roboto_500.eot?#iefix') format('embedded-opentype'),
 		url('Roboto_500.woff') format('woff'),
 		url('Roboto_500.woff2') format('woff2'),
-		url('Roboto_500.svg#Roboto') format('svg'),
+		url('Roboto_500.svg#Roboto') format('svg');
+}
 @font-face {
 	font-family: 'Roboto';
 	font-style: normal;
@@ -41,4 +44,5 @@
 		url('Roboto_700.eot?#iefix') format('embedded-opentype'),
 		url('Roboto_700.woff') format('woff'),
 		url('Roboto_700.woff2') format('woff2'),
-		url('Roboto_700.svg#Roboto') format('svg'),
+		url('Roboto_700.svg#Roboto') format('svg');
+}

--- a/assets/fonts/readable.fonts.css
+++ b/assets/fonts/readable.fonts.css
@@ -8,7 +8,8 @@
 		url('Raleway_400.eot?#iefix') format('embedded-opentype'),
 		url('Raleway_400.woff') format('woff'),
 		url('Raleway_400.woff2') format('woff2'),
-		url('Raleway_400.svg#Raleway') format('svg'),
+		url('Raleway_400.svg#Raleway') format('svg');
+}
 @font-face {
 	font-family: 'Raleway';
 	font-style: normal;
@@ -19,4 +20,5 @@
 		url('Raleway_700.eot?#iefix') format('embedded-opentype'),
 		url('Raleway_700.woff') format('woff'),
 		url('Raleway_700.woff2') format('woff2'),
-		url('Raleway_700.svg#Raleway') format('svg'),
+		url('Raleway_700.svg#Raleway') format('svg');
+}

--- a/assets/fonts/sandstone.fonts.css
+++ b/assets/fonts/sandstone.fonts.css
@@ -8,7 +8,8 @@
 		url('Roboto_400.eot?#iefix') format('embedded-opentype'),
 		url('Roboto_400.woff') format('woff'),
 		url('Roboto_400.woff2') format('woff2'),
-		url('Roboto_400.svg#Roboto') format('svg'),
+		url('Roboto_400.svg#Roboto') format('svg');
+}
 @font-face {
 	font-family: 'Roboto';
 	font-style: normal;
@@ -19,7 +20,8 @@
 		url('Roboto_500.eot?#iefix') format('embedded-opentype'),
 		url('Roboto_500.woff') format('woff'),
 		url('Roboto_500.woff2') format('woff2'),
-		url('Roboto_500.svg#Roboto') format('svg'),
+		url('Roboto_500.svg#Roboto') format('svg');
+}
 @font-face {
 	font-family: 'Roboto';
 	font-style: normal;
@@ -30,4 +32,5 @@
 		url('Roboto_700.eot?#iefix') format('embedded-opentype'),
 		url('Roboto_700.woff') format('woff'),
 		url('Roboto_700.woff2') format('woff2'),
-		url('Roboto_700.svg#Roboto') format('svg'),
+		url('Roboto_700.svg#Roboto') format('svg');
+}

--- a/assets/fonts/simplex.fonts.css
+++ b/assets/fonts/simplex.fonts.css
@@ -8,7 +8,8 @@
 		url('Open_Sans_400.eot?#iefix') format('embedded-opentype'),
 		url('Open_Sans_400.woff') format('woff'),
 		url('Open_Sans_400.woff2') format('woff2'),
-		url('Open_Sans_400.svg#OpenSans') format('svg'),
+		url('Open_Sans_400.svg#OpenSans') format('svg');
+}
 @font-face {
 	font-family: 'Open Sans';
 	font-style: normal;
@@ -19,4 +20,5 @@
 		url('Open_Sans_700.eot?#iefix') format('embedded-opentype'),
 		url('Open_Sans_700.woff') format('woff'),
 		url('Open_Sans_700.woff2') format('woff2'),
-		url('Open_Sans_700.svg#OpenSans') format('svg'),
+		url('Open_Sans_700.svg#OpenSans') format('svg');
+}

--- a/assets/fonts/solar.fonts.css
+++ b/assets/fonts/solar.fonts.css
@@ -8,7 +8,8 @@
 		url('Source_Sans_Pro_300.eot?#iefix') format('embedded-opentype'),
 		url('Source_Sans_Pro_300.woff') format('woff'),
 		url('Source_Sans_Pro_300.woff2') format('woff2'),
-		url('Source_Sans_Pro_300.svg#SourceSansPro') format('svg'),
+		url('Source_Sans_Pro_300.svg#SourceSansPro') format('svg');
+}
 @font-face {
 	font-family: 'Source Sans Pro';
 	font-style: normal;
@@ -19,7 +20,8 @@
 		url('Source_Sans_Pro_400.eot?#iefix') format('embedded-opentype'),
 		url('Source_Sans_Pro_400.woff') format('woff'),
 		url('Source_Sans_Pro_400.woff2') format('woff2'),
-		url('Source_Sans_Pro_400.svg#SourceSansPro') format('svg'),
+		url('Source_Sans_Pro_400.svg#SourceSansPro') format('svg');
+}
 @font-face {
 	font-family: 'Source Sans Pro';
 	font-style: normal;
@@ -30,4 +32,5 @@
 		url('Source_Sans_Pro_700.eot?#iefix') format('embedded-opentype'),
 		url('Source_Sans_Pro_700.woff') format('woff'),
 		url('Source_Sans_Pro_700.woff2') format('woff2'),
-		url('Source_Sans_Pro_700.svg#SourceSansPro') format('svg'),
+		url('Source_Sans_Pro_700.svg#SourceSansPro') format('svg');
+}

--- a/assets/fonts/spacelab.fonts.css
+++ b/assets/fonts/spacelab.fonts.css
@@ -8,7 +8,8 @@
 		url('Open_Sans_400italic.eot?#iefix') format('embedded-opentype'),
 		url('Open_Sans_400italic.woff') format('woff'),
 		url('Open_Sans_400italic.woff2') format('woff2'),
-		url('Open_Sans_400italic.svg#OpenSans') format('svg'),
+		url('Open_Sans_400italic.svg#OpenSans') format('svg');
+}
 @font-face {
 	font-family: 'Open Sans';
 	font-style: italic;
@@ -19,7 +20,8 @@
 		url('Open_Sans_700italic.eot?#iefix') format('embedded-opentype'),
 		url('Open_Sans_700italic.woff') format('woff'),
 		url('Open_Sans_700italic.woff2') format('woff2'),
-		url('Open_Sans_700italic.svg#OpenSans') format('svg'),
+		url('Open_Sans_700italic.svg#OpenSans') format('svg');
+}
 @font-face {
 	font-family: 'Open Sans';
 	font-style: normal;
@@ -30,7 +32,8 @@
 		url('Open_Sans_400.eot?#iefix') format('embedded-opentype'),
 		url('Open_Sans_400.woff') format('woff'),
 		url('Open_Sans_400.woff2') format('woff2'),
-		url('Open_Sans_400.svg#OpenSans') format('svg'),
+		url('Open_Sans_400.svg#OpenSans') format('svg');
+}
 @font-face {
 	font-family: 'Open Sans';
 	font-style: normal;
@@ -41,4 +44,5 @@
 		url('Open_Sans_700.eot?#iefix') format('embedded-opentype'),
 		url('Open_Sans_700.woff') format('woff'),
 		url('Open_Sans_700.woff2') format('woff2'),
-		url('Open_Sans_700.svg#OpenSans') format('svg'),
+		url('Open_Sans_700.svg#OpenSans') format('svg');
+}

--- a/assets/fonts/superhero.fonts.css
+++ b/assets/fonts/superhero.fonts.css
@@ -8,7 +8,8 @@
 		url('Lato_300.eot?#iefix') format('embedded-opentype'),
 		url('Lato_300.woff') format('woff'),
 		url('Lato_300.woff2') format('woff2'),
-		url('Lato_300.svg#Lato') format('svg'),
+		url('Lato_300.svg#Lato') format('svg');
+}
 @font-face {
 	font-family: 'Lato';
 	font-style: normal;
@@ -19,7 +20,8 @@
 		url('Lato_400.eot?#iefix') format('embedded-opentype'),
 		url('Lato_400.woff') format('woff'),
 		url('Lato_400.woff2') format('woff2'),
-		url('Lato_400.svg#Lato') format('svg'),
+		url('Lato_400.svg#Lato') format('svg');
+}
 @font-face {
 	font-family: 'Lato';
 	font-style: normal;
@@ -30,4 +32,5 @@
 		url('Lato_700.eot?#iefix') format('embedded-opentype'),
 		url('Lato_700.woff') format('woff'),
 		url('Lato_700.woff2') format('woff2'),
-		url('Lato_700.svg#Lato') format('svg'),
+		url('Lato_700.svg#Lato') format('svg');
+}

--- a/assets/fonts/united.fonts.css
+++ b/assets/fonts/united.fonts.css
@@ -8,7 +8,8 @@
 		url('Ubuntu_400.eot?#iefix') format('embedded-opentype'),
 		url('Ubuntu_400.woff') format('woff'),
 		url('Ubuntu_400.woff2') format('woff2'),
-		url('Ubuntu_400.svg#Ubuntu') format('svg'),
+		url('Ubuntu_400.svg#Ubuntu') format('svg');
+}
 @font-face {
 	font-family: 'Ubuntu';
 	font-style: normal;
@@ -19,4 +20,5 @@
 		url('Ubuntu_700.eot?#iefix') format('embedded-opentype'),
 		url('Ubuntu_700.woff') format('woff'),
 		url('Ubuntu_700.woff2') format('woff2'),
-		url('Ubuntu_700.svg#Ubuntu') format('svg'),
+		url('Ubuntu_700.svg#Ubuntu') format('svg');
+}

--- a/assets/fonts/yeti.fonts.css
+++ b/assets/fonts/yeti.fonts.css
@@ -8,7 +8,8 @@
 		url('Open_Sans_300italic.eot?#iefix') format('embedded-opentype'),
 		url('Open_Sans_300italic.woff') format('woff'),
 		url('Open_Sans_300italic.woff2') format('woff2'),
-		url('Open_Sans_300italic.svg#OpenSans') format('svg'),
+		url('Open_Sans_300italic.svg#OpenSans') format('svg');
+}
 @font-face {
 	font-family: 'Open Sans';
 	font-style: italic;
@@ -19,7 +20,8 @@
 		url('Open_Sans_400italic.eot?#iefix') format('embedded-opentype'),
 		url('Open_Sans_400italic.woff') format('woff'),
 		url('Open_Sans_400italic.woff2') format('woff2'),
-		url('Open_Sans_400italic.svg#OpenSans') format('svg'),
+		url('Open_Sans_400italic.svg#OpenSans') format('svg');
+}
 @font-face {
 	font-family: 'Open Sans';
 	font-style: italic;
@@ -30,7 +32,8 @@
 		url('Open_Sans_700italic.eot?#iefix') format('embedded-opentype'),
 		url('Open_Sans_700italic.woff') format('woff'),
 		url('Open_Sans_700italic.woff2') format('woff2'),
-		url('Open_Sans_700italic.svg#OpenSans') format('svg'),
+		url('Open_Sans_700italic.svg#OpenSans') format('svg');
+}
 @font-face {
 	font-family: 'Open Sans';
 	font-style: normal;
@@ -41,7 +44,8 @@
 		url('Open_Sans_400.eot?#iefix') format('embedded-opentype'),
 		url('Open_Sans_400.woff') format('woff'),
 		url('Open_Sans_400.woff2') format('woff2'),
-		url('Open_Sans_400.svg#OpenSans') format('svg'),
+		url('Open_Sans_400.svg#OpenSans') format('svg');
+}
 @font-face {
 	font-family: 'Open Sans';
 	font-style: normal;
@@ -52,7 +56,8 @@
 		url('Open_Sans_300.eot?#iefix') format('embedded-opentype'),
 		url('Open_Sans_300.woff') format('woff'),
 		url('Open_Sans_300.woff2') format('woff2'),
-		url('Open_Sans_300.svg#OpenSans') format('svg'),
+		url('Open_Sans_300.svg#OpenSans') format('svg');
+}
 @font-face {
 	font-family: 'Open Sans';
 	font-style: normal;
@@ -63,4 +68,5 @@
 		url('Open_Sans_700.eot?#iefix') format('embedded-opentype'),
 		url('Open_Sans_700.woff') format('woff'),
 		url('Open_Sans_700.woff2') format('woff2'),
-		url('Open_Sans_700.svg#OpenSans') format('svg'),
+		url('Open_Sans_700.svg#OpenSans') format('svg');
+}


### PR DESCRIPTION
Looks like all the CSS files for the fonts for each theme was broken. Also changed the way the font files are detected for stylesheet inclusion. tpl_incdir() tells you the real path on the server, whereas tpl_basedir() tells you the web path. Web path did not work with PHP's file_exists. 