### PR TITLE
Improve accessibility by adding a skiplink and label to navigation

### DIFF
--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -45,6 +45,5 @@ $lang['config_page']             = 'Seite';
 
 // Accessibility labels
 // These are hidden from normal users, but are visible to screenreaders and other software interacting with the site
-$lang['a11y_skiplink']           = 'Zum Inhalt springen'; 
 $lang['a11y_navbartoggle']       = 'Navigation anzeigen';
 

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -43,3 +43,8 @@ $lang['config_google_analytics'] = 'Google Analytics';
 $lang['config_browser_title']    = 'Browser Titel';
 $lang['config_page']             = 'Seite';
 
+// Accessibility labels
+// These are hidden from normal users, but are visible to screenreaders and other software interacting with the site
+$lang['a11y_skiplink']           = 'Zum Inhalt springen'; 
+$lang['a11y_navbartoggle']       = 'Navigation anzeigen';
+

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -40,6 +40,5 @@ $lang['config_page']             = 'Page';
 
 // Accessibility labels
 // These are hidden from normal users, but are visible to screenreaders and other software interacting with the site
-$lang['a11y_skiplink']           = 'Skip to content'; 
 $lang['a11y_navbartoggle']       = 'Show navigation';
 

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -38,3 +38,7 @@ $lang['config_google_analytics'] = 'Google Analytics';
 $lang['config_browser_title']    = 'Browser Title';
 $lang['config_page']             = 'Page';
 
+// Accessibility labels
+// These are hidden from normal users, but are visible to screenreaders and other software interacting with the site
+$lang['a11y_skiplink']           = 'Skip to content'; 
+$lang['a11y_navbartoggle']       = 'Show navigation';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -42,3 +42,4 @@ $lang['config_page']             = 'Page';
 // These are hidden from normal users, but are visible to screenreaders and other software interacting with the site
 $lang['a11y_skiplink']           = 'Skip to content'; 
 $lang['a11y_navbartoggle']       = 'Show navigation';
+

--- a/main.php
+++ b/main.php
@@ -14,6 +14,8 @@ require_once('tpl/functions.php');
 
 header('X-UA-Compatible: IE=edge,chrome=1');
 
+global $lang;
+
 ?><!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="<?php echo $conf['lang'] ?>" dir="<?php echo $lang['direction'] ?>" class="no-js">
 <head>
@@ -41,7 +43,7 @@ header('X-UA-Compatible: IE=edge,chrome=1');
 <body class="<?php echo $TPL->getClasses() ?>" data-page-id="<?php echo $ID ?>"><div class="dokuwiki"><?php /* CSS class for Plugins and user styles */ ?>
 
     <header id="dokuwiki__header" class="dw-container dokuwiki container<?php echo ($TPL->getConf('fluidContainer')) ? '-fluid mx-5' : '' ?>">
-    <a href="#dokuwiki__content" class="sr-only sr-only-focusable"><?php echo $lang["a11y_skiplink"]; ?></a>
+    <a href="#dokuwiki__content" class="sr-only sr-only-focusable"><?php echo $lang["skip_to_content"]; ?></a>
     <?php
 
         tpl_includeFile('topheader.html');

--- a/main.php
+++ b/main.php
@@ -41,6 +41,7 @@ header('X-UA-Compatible: IE=edge,chrome=1');
 <body class="<?php echo $TPL->getClasses() ?>" data-page-id="<?php echo $ID ?>"><div class="dokuwiki"><?php /* CSS class for Plugins and user styles */ ?>
 
     <header id="dokuwiki__header" class="dw-container dokuwiki container<?php echo ($TPL->getConf('fluidContainer')) ? '-fluid mx-5' : '' ?>">
+    <a href="#dokuwiki__content" class="sr-only sr-only-focusable"><?php echo $lang["a11y_skiplink"]; ?></a>
     <?php
 
         tpl_includeFile('topheader.html');

--- a/tpl/navbar.php
+++ b/tpl/navbar.php
@@ -24,7 +24,7 @@ $home_link        = ($TPL->getConf('homePageURL') ? $TPL->getConf('homePageURL')
 
         <div class="navbar-header">
 
-            <button class="navbar-toggle" type="button" data-toggle="collapse" data-target=".navbar-collapse">
+            <button class="navbar-toggle" type="button" data-toggle="collapse" data-target=".navbar-collapse" aria-label="<?php echo $lang["a11y_navbartoggle"]; ?>">
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>

--- a/tpl/navbar.php
+++ b/tpl/navbar.php
@@ -24,7 +24,7 @@ $home_link        = ($TPL->getConf('homePageURL') ? $TPL->getConf('homePageURL')
 
         <div class="navbar-header">
 
-            <button class="navbar-toggle" type="button" data-toggle="collapse" data-target=".navbar-collapse" aria-label="<?php echo $lang["a11y_navbartoggle"]; ?>">
+            <button class="navbar-toggle" type="button" data-toggle="collapse" data-target=".navbar-collapse" aria-label="<?php echo tpl_getLang("a11y_navbartoggle"); ?>">
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>


### PR DESCRIPTION
This PR seeks to improve the accessibility of Dokuwiki pages using the bootstrap3 template by adding a skip link which allows users with screenreaders to skip any navigation whatsoever and get right to the content. It also adds a descriptive aria-label to the collapse navigation button so it's easier for users to make sense of it's function. For this, it was necessary to add a new translation label to the template. I've translated it to German already.