### PR TITLE
Extra check on login page for PHP>=8.0

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -1218,7 +1218,7 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
      */
     public function getNavbar()
     {
-        if ($this->getConf('showNavbar') === 'logged' && !$_SERVER['REMOTE_USER']) {
+        if ($this->getConf('showNavbar') === 'logged' && !array_key_exists('REMOTE_USER', $_SERVER) || !$_SERVER['REMOTE_USER']) {
             return false;
         }
 


### PR DESCRIPTION
Check case if `$_SERVER` global variable does not contain the `REMOTE_USER` key. (spotted when updated php from 7.4 to 8.0)